### PR TITLE
cli が実行できなかったので happy-dom を正しく使うようにした

### DIFF
--- a/apps/cli/Makefile
+++ b/apps/cli/Makefile
@@ -1,6 +1,6 @@
 # -*- makefile -*-
 
-ESBUILD = ../../node_modules/.bin/esbuild
+ESBUILD = npx esbuild
 SRC_DIR = src
 DIST_DIR = dist
 
@@ -10,12 +10,13 @@ usage:
 	@echo "Usage: make [build|tree|test]"
 
 build:
-	../../node_modules/.bin/esbuild \
+	$(ESBUILD) \
 		--bundle \
 		--platform=node \
 		--target=esnext \
 		--outfile=$(DIST_DIR)/bangumi2gcal.js \
-		$(SRC_DIR)/app/bangumi2gcal.ts 
+		$(SRC_DIR)/app/bangumi2gcal.ts
+	chmod +x $(DIST_DIR)/bangumi2gcal.js
 	wc -l $(DIST_DIR)/bangumi2gcal.js
 
 tree:

--- a/apps/cli/src/handler/bangumi2gcal_handler.ts
+++ b/apps/cli/src/handler/bangumi2gcal_handler.ts
@@ -18,16 +18,27 @@ export class Bangumi2GcalHandler {
         const DEBUG = Boolean(process.env.BANGUMI_DEBUG);
         // TODO: エラー処理どうしよう
         try {
-            const epURL = await Bangumi2GcalService.getGCalEpURLFromBangumiURL(bangumiURL);
+            if ( DEBUG && globalThis['document'] ) {
+                console.info('globalThis に document が既に存在します');
+            }
+            const document = await Bangumi2GcalService.getHappyDomDocument(bangumiURL);
+            if ( DEBUG ) {
+                console.log(`document.body = ${document.body}`);
+                console.log(`document.querySelector('body') = ${document.querySelector('body')}`);
+            }
+            const epURL = await Bangumi2GcalService.getGCalEpURLFromBangumiURL(bangumiURL, document);
+            // 実際に URL を標準出力に出力する
+            // eslint-disable-next-line no-console
             console.log(epURL);
-            return Bangumi2GcalHandler.RETURN_CODE_SUCCESS;
-        } catch (e) {
+            return this.RETURN_CODE_SUCCESS;
+        } catch (e: unknown) {
             if (DEBUG) {
                 // re-throw
                 throw e;
             }
-            console.error(`エラーが発生しました: ${e.message}`);
-            return Bangumi2GcalHandler.RETURN_CODE_ERROR;
+            console.error(`Bangumi2GcalService: エラーが発生しました: ${e}`);
+            return this.RETURN_CODE_ERROR;
         }
     }
+
 }

--- a/apps/cli/src/handler/bangumi2gcal_handler.ts
+++ b/apps/cli/src/handler/bangumi2gcal_handler.ts
@@ -1,8 +1,19 @@
 import { Bangumi2GcalService } from '../service/bangumi2gcal_service';
 
 export class Bangumi2GcalHandler {
-    static RETURN_CODE_SUCCESS = 0;
-    static RETURN_CODE_ERROR = 1;
+    /**
+     * コマンドが正常終了した時のリターンコード
+     */
+    static readonly RETURN_CODE_SUCCESS = 0;
+    /**
+     * コマンドがエラー終了した時のリターンコード
+     */
+    static readonly RETURN_CODE_ERROR = 1;
+    /**
+     * bangumi2gcal コマンド処理のハンドラ。このメソッド内で標準出力に Google カレンダーの Event Publisher URL を出力をする（返り値ではないことに注意）。
+     * @param bangumiURL - 番組表.Gコードの番組URL。テレビもしくはラジオの番組URLを指定する。
+     * @returns - プロセス終了時のリターンコード。実際にプロセス終了はこれを呼び出した Application 層で後処理をした後に行う。
+     */
     static async bangumi2gcal(bangumiURL: string): Promise<number> {
         const DEBUG = Boolean(process.env.BANGUMI_DEBUG);
         // TODO: エラー処理どうしよう

--- a/apps/cli/src/service/bangumi2gcal_service.ts
+++ b/apps/cli/src/service/bangumi2gcal_service.ts
@@ -11,10 +11,13 @@ export class Bangumi2GcalService {
 
     /**
      * fetch インターフェースの大したことないラッパー
-     * @param {string} url 
-     * @returns {Promise<Response>}
+     * @param - URL
+     * @returns - URL のレスポンス結果から取り出した string で解決する Promise。ただし異常時は例外を投げる
      */
-    static async fetch(url: string | URL | Request, option?: Record<string, any>): Promise<Response> {
+    static async fetch(
+        url: string | URL | Request,
+        option?: Record<string, any>
+    ): Promise<Response> {
         // この fetch はグローバルの方の fetch
         const response = await fetch(url, {
             headers: {
@@ -42,10 +45,14 @@ export class Bangumi2GcalService {
 
     /**
      * 番組URLから Google カレンダーの Event Publisher URL を生成する。
-     * @param bangumiURL - 番組URL
+     * @param bangumiURL - 番組URL。これは詳細テキストに入れる URL として使われるだけで、この関数はこの URL へ HTTP リクエストを送ることはない。外部から自力で bangumiURL の内容を取得する必要がある場合は、第2引数の document を getHappyDomDocument(bangumiURL) などから作る必要がある。
+     * @param document - Document。DOM がすでにある場合は document を渡す。ない場合は getHappyDomDocument(bangumiURL) などから作る必要がある。
      * @returns - Google カレンダーの Event Publisher URL で解決する Promise
      */
-    static async getGCalEpURLFromBangumiURL(bangumiURL: string): Promise<string | undefined> {
+    static async getGCalEpURLFromBangumiURL(
+        bangumiURL: string,
+        document: Document
+    ): Promise<string | undefined> {
         // const response = await Bangumi2GcalService.fetch(bangumiURL);
         // if (!response.ok) {
         //     throw new Error(`fetch error: ${response.status} ${response.statusText}`);
@@ -63,8 +70,10 @@ export class Bangumi2GcalService {
         // document.body.innerHTML = bangumiContents;
 
         const info: BangumiInfo = BangumiDomain.parseDocument(document);
-
-        const epURL = BangumiDomain.createGoogleCalenderEventPublisherURL(info, bangumiURL);
+        const epURL = BangumiDomain.createGoogleCalenderEventPublisherURL(
+            info,
+            bangumiURL
+        );
         return epURL;
     }
 

--- a/apps/cli/src/service/bangumi2gcal_service.ts
+++ b/apps/cli/src/service/bangumi2gcal_service.ts
@@ -96,12 +96,12 @@ export class Bangumi2GcalService {
 
     /**
      * 番組URLから JSDOM で document を生成する。現在は happy-dom を使うことにしているので使わない。呼び出したら必ず例外を発生させるようにしている。
-     * @param bangumiURL - 番組URL
+     * @param _bangumiURL - 番組URL
      * @returns - JSDOM から生成した document で解決する Promise
      */
-    static async getJSDOMDocument(bangumiURL: string): Promise<Document> {
+    static async getJSDOMDocument(_bangumiURL: string): Promise<Document> {
         throw new Error('getJSONDOMDocument() is outdated. Use getHappyDomDocument() instead.');
-        // const response = await Bangumi2GcalService.fetch(bangumiURL);
+        // const response = await Bangumi2GcalService.fetch(_bangumiURL);
         // if (!response.ok) {
         //     throw new Error(`fetch error: ${response.status} ${response.statusText}`);
         // }


### PR DESCRIPTION
2ヶ月ぶりくらいに開発物に触れたところ、cli を実行しようとしたらできなかったので修正。

どうも happy-dom をうまく使えていなかったよう。

esbuild でビルドしているものの、npx ts-node を使って typescript パッケージの警告レベルでもあまり警告が出ないようにした（若干出ているけれど、おいおい直す）。